### PR TITLE
Drop unnecessary $(mise env)

### DIFF
--- a/zsh-mise.plugin.zsh
+++ b/zsh-mise.plugin.zsh
@@ -10,9 +10,6 @@ fi
 # Add 'mise' hooks to the zsh shell
 eval "$(mise activate zsh)"
 
-# Update the environment here to ensure immediately available
-eval "$(mise env)"
-
 # Completions directory for `mise` command
 local COMPLETIONS_DIR="${0:A:h}/completions"
 


### PR DESCRIPTION
Removing the second `mise` invocation seems to have no effect, to the best of my ability to discern; and it both

1. improves startup-time, and
2. reduces line-noise if there's any missing packages (see jdx/mise#1561).